### PR TITLE
Fix getting last object

### DIFF
--- a/lib/src/main/java/com/fourlastor/dante/html/BlockStyleListener.java
+++ b/lib/src/main/java/com/fourlastor/dante/html/BlockStyleListener.java
@@ -65,7 +65,7 @@ abstract class BlockStyleListener implements BlockListener {
         if (objs.length == 0) {
             return null;
         } else {
-            return objs[objs.length - 1];
+            return objs[0];
         }
     }
 


### PR DESCRIPTION
getSpans() returns the last added object as the first element of the array and not the last one: https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/text/SpannableStringBuilder.java#848

This issue can be reproduced by wrapping text in two block style listeners that start and end at the same position, e.g. `<tag1><tag2>foo</tag2></tag1>`