### PR TITLE
Fix TextAppearanceListener only being applied on last tag

### DIFF
--- a/lib/src/main/java/com/fourlastor/dante/html/TextAppearanceListener.java
+++ b/lib/src/main/java/com/fourlastor/dante/html/TextAppearanceListener.java
@@ -5,15 +5,17 @@ import android.text.style.TextAppearanceSpan;
 
 class TextAppearanceListener extends BlockStyleListener {
 
-    private final TextAppearanceSpan span;
+    private final Context context;
+    private final int appearance;
 
     TextAppearanceListener(Context context, int appearance, String... tags) {
         super(tags);
-        this.span = new TextAppearanceSpan(context, appearance);
+        this.context = context;
+        this.appearance = appearance;
     }
 
     @Override
     protected Object getStyleSpan() {
-        return span;
+        return new TextAppearanceSpan(context, appearance);
     }
 }


### PR DESCRIPTION
This fixes a bug where the TextAppearance was only applied on the last occurned of a tag. For example for `<tag1>foo</tag1><tag1>bar</tag1>`, the TextAppearance was only applied to `bar`.

This was caused by the same span being reused because of the way BlockStyleListener is implemented. This fixes this issue by simply creating a TextAppearanceSpan for every usage instead, which aligns it with the other listeners.