### PR TITLE
Expose blockStyle builder

### DIFF
--- a/app/src/main/java/com/fourlastor/dante/MainActivity.java
+++ b/app/src/main/java/com/fourlastor/dante/MainActivity.java
@@ -6,8 +6,10 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Spanned;
+import android.text.style.StrikethroughSpan;
 import android.widget.TextView;
 
+import com.fourlastor.dante.html.BlockStyleListener;
 import com.fourlastor.dante.html.FlavoredHtml;
 import com.fourlastor.dante.html.ImgLoader;
 import com.squareup.picasso.Picasso;
@@ -47,6 +49,12 @@ public class MainActivity extends AppCompatActivity {
                         }
                     }
                 })
+                .blockStyle(new BlockStyleListener("s") {
+                    @Override
+                    protected Object getStyleSpan() {
+                        return new StrikethroughSpan();
+                    }
+                })
                 .build();
     }
 
@@ -62,7 +70,7 @@ public class MainActivity extends AppCompatActivity {
                 "\n" +
                 "<ol>\n" +
                 "   <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>\n" +
-                "   <li>Aliquam tincidunt mauris eu risus.</li>\n" +
+                "   <li><s>Aliquam tincidunt mauris eu risus.</s></li>\n" +
                 "</ol>\n" +
                 "\n" +
                 "<blockquote><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.</p></blockquote>\n" +

--- a/lib/src/main/java/com/fourlastor/dante/html/BlockStyleListener.java
+++ b/lib/src/main/java/com/fourlastor/dante/html/BlockStyleListener.java
@@ -11,11 +11,11 @@ import com.fourlastor.dante.parser.BlockListener;
 import java.util.Arrays;
 import java.util.List;
 
-abstract class BlockStyleListener implements BlockListener {
+public abstract class BlockStyleListener implements BlockListener {
 
     private List<String> tags;
 
-    BlockStyleListener(String... tags) {
+    public BlockStyleListener(String... tags) {
         this.tags = Arrays.asList(tags);
     }
 

--- a/lib/src/main/java/com/fourlastor/dante/html/FlavoredHtml.java
+++ b/lib/src/main/java/com/fourlastor/dante/html/FlavoredHtml.java
@@ -57,6 +57,11 @@ public class FlavoredHtml {
             return this;
         }
 
+        public Builder blockStyle(BlockStyleListener listener) {
+            dante.register(listener);
+            return this;
+        }
+
         public FlavoredHtml build() {
             return new FlavoredHtml(dante);
         }


### PR DESCRIPTION
This enables support for any type of spannable. As an example I am adding support for `StrikethroughSpan`.

The "price" for this is that `BlockStyleListener` is public now, but this seems a good tradeoff to allow for this flexibility.