### PR TITLE
Remove allowBackup

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,6 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="fm.pause.stringparty">
-
-    <application android:allowBackup="true" />
-
-</manifest>
+<manifest package="fm.pause.stringparty" />


### PR DESCRIPTION
Removes`android:allowBackup` as it was causing errors if the app did not have it set.